### PR TITLE
Improve leveling and NA handling for factors

### DIFF
--- a/.Rproj.user/F38F6BEA/build_options
+++ b/.Rproj.user/F38F6BEA/build_options
@@ -1,4 +1,0 @@
-auto_roxygenize_for_build_and_reload="0"
-auto_roxygenize_for_build_package="1"
-auto_roxygenize_for_check="1"
-makefile_args=""

--- a/.Rproj.user/F38F6BEA/build_options
+++ b/.Rproj.user/F38F6BEA/build_options
@@ -1,0 +1,4 @@
+auto_roxygenize_for_build_and_reload="0"
+auto_roxygenize_for_build_package="1"
+auto_roxygenize_for_check="1"
+makefile_args=""

--- a/R/vector_bucketer.R
+++ b/R/vector_bucketer.R
@@ -39,8 +39,10 @@ VectorBucketer <- R6Class("VectorBucketer",
       tab <- table(cut_vector)
       tab <- tab[order(tab, decreasing=TRUE)][1:(buckets - 1)]
       cut_vector <- as.character(cut_vector)
-      cut_vector[!cut_vector %in% names(tab)] <- "OTHER"
-      as.factor(cut_vector)
+      cut_vector[!cut_vector %in% names(tab) & !is.na(cut_vector)] <- "OTHER"
+      cut_vector[is.na(cut_vector)] <- "NA"
+      cut_vector <- factor(cut_vector, levels=c(names(tab), "OTHER", "NA"))
+      cut_vector[drop=TRUE]
     }
   )
 )

--- a/tests/testthat/test_end_to_end.R
+++ b/tests/testthat/test_end_to_end.R
@@ -12,6 +12,8 @@ make_fake_data <- function(N) {
 set.seed(1234)
 df <- make_fake_data(1e4)
 df$factor1 <- sample(letters, 1e4, TRUE)
+df$factor2 <- c(sample(letters, 9e3, TRUE), rep(NA, 1e3))
+df$factor3 <- sample(letters[1:5], 1e4, TRUE)
 plot_cols <- c("response1", "response2", "response3")
 
 even_unif <- universe(df, plot_cols, "numeric1", 20)
@@ -20,6 +22,8 @@ even_cart <- universe(df, plot_cols, "numeric1", 20, scale = "cartesian")
 quant_cart <- universe(df, plot_cols, "numeric1", 20, cut_type = "quantile",
                        scale = "cartesian")
 factor_unif <- universe(df, plot_cols, "factor1", 20)
+factor_unif_na <- universe(df, plot_cols, "factor2", 20)
+factor_unif_no_other <- universe(df, plot_cols, "factor3", 20)
 
 
 test_that("even and uniform working end-to-end", {
@@ -119,7 +123,14 @@ test_that("factor plots working end-to-end", {
   expect_is(factor_unif$grp_by_col, "factor")
   expect_equal(nlevels(factor_unif$grp_by_col), 20)
 
-  expected_val <- c(405, 402, 398, 375, 381, 406, 378, 399, 398, 379, 400, 2501,
-                    403, 393, 395, 408, 387, 392, 422, 378)
+  expected_val <- c(422, 408, 406, 405, 403, 402, 400, 399, 398, 398, 395,
+                    393, 392, 387, 381, 379, 378, 378, 375, 2501)
   expect_equal(factor_unif$value, expected_val)
+
+  expected_val_na <- c(414, 404, 384, 377, 362, 360, 358, 353, 352, 349, 349,
+                       348, 348, 344, 340, 338, 336, 334, 330, 2220, 1000)
+  expect_equal(factor_unif_na$value, expected_val_na)
+
+  expected_val_no_other <- c(2061, 2034, 2002, 1991, 1912)
+  expect_equal(factor_unif_no_other$value, expected_val_no_other)
 })


### PR DESCRIPTION
These changes result in the following:
- If there are any `NA` values in a column, they get their own factor level and are no longer grouped into the `OTHER` category
- Factors are leveled accordingly:
  1. The distinct groups of the column sorted by size
  2. `OTHER`, if applicable
  3. `NA`, if applicable

The end-to-end tests have been updated to reflect these changes.

Some of this is arguably my personal preference, so feel free to cherry pick from these changes as you see fit.  It might also be worth considering a `factor_sort` argument that offers sorting options for factors (e.g. alphabetically, by size, or by variability between the plotted values).
